### PR TITLE
Fix Recaptcha-initialisation being too fast for QR

### DIFF
--- a/4chan_x.user.js
+++ b/4chan_x.user.js
@@ -2357,7 +2357,7 @@
               value: ''
             }));
             $.addClass(QR.el, 'captcha');
-            $.globalEval('(window.setTimeout(function () {window.grecaptcha.render(document.getElementById("g-recaptcha"), {sitekey: "6Ldp2bsSAAAAAAJ5uyx_lx34lJeEpTLVkP5k04qc", theme: "light", callback: (' + (Conf['Auto Submit'] ? 'function (res) {var sb = document.getElementById("x_QR_Submit"); if(sb) sb.click(); }' : 'function (res) {}') + ') });}),500)()');
+            $.globalEval('(window.setTimeout(function () {window.grecaptcha.render(document.getElementById("g-recaptcha"), {sitekey: "6Ldp2bsSAAAAAAJ5uyx_lx34lJeEpTLVkP5k04qc", theme: "light", callback: (' + (Conf['Auto Submit'] ? 'function (res) {var sb = document.getElementById("x_QR_Submit"); if(sb) sb.click(); }' : 'function (res) {}') + ') });}),1000)()');
             $.after($('.textarea', QR.el), $.id('g-recaptcha'));
           } else {
             $.addClass(QR.el, 'captcha');

--- a/4chan_x.user.js
+++ b/4chan_x.user.js
@@ -2357,7 +2357,7 @@
               value: ''
             }));
             $.addClass(QR.el, 'captcha');
-            $.globalEval('(function () {window.grecaptcha.render(document.getElementById("g-recaptcha"), {sitekey: "6Ldp2bsSAAAAAAJ5uyx_lx34lJeEpTLVkP5k04qc", theme: "light", callback: (' + (Conf['Auto Submit'] ? 'function (res) {var sb = document.getElementById("x_QR_Submit"); if(sb) sb.click(); }' : 'function (res) {}') + ') });})()');
+            $.globalEval('(window.setTimeout(function () {window.grecaptcha.render(document.getElementById("g-recaptcha"), {sitekey: "6Ldp2bsSAAAAAAJ5uyx_lx34lJeEpTLVkP5k04qc", theme: "light", callback: (' + (Conf['Auto Submit'] ? 'function (res) {var sb = document.getElementById("x_QR_Submit"); if(sb) sb.click(); }' : 'function (res) {}') + ') });}),500)()');
             $.after($('.textarea', QR.el), $.id('g-recaptcha'));
           } else {
             $.addClass(QR.el, 'captcha');


### PR DESCRIPTION
For some reason a while ago, recaptcha stopped being initialised upon loading the site properly for me, leaving the QR with an empty recaptcha-field, unless I'm clicking on "Post A Reply" manually.
In the console an error about window.grecaptcha.render not being a valid function would pop up.

After adding the timeout, the problem went away.